### PR TITLE
Android Google Maps known issue bypass

### DIFF
--- a/lib/src/marker_url.dart
+++ b/lib/src/marker_url.dart
@@ -14,10 +14,11 @@ String getMapMarkerUrl({
   switch (mapType) {
     case MapType.google:
       return Utils.buildUrl(
-        url: Platform.isIOS ? 'comgooglemaps://' : 'geo:0,0',
+        url: Platform.isIOS ? 'comgooglemaps://' : 'geo:${coords.latitude},${coords.longitude}',
         queryParams: {
-          'q': '${coords.latitude},${coords.longitude}($title)',
+          'q': '$title',
           'zoom': '$zoomLevel',
+          'center': Platform.isIOS ? '${coords.latitude},${coords.longitude}' : ''
         },
       );
 

--- a/lib/src/marker_url.dart
+++ b/lib/src/marker_url.dart
@@ -16,7 +16,7 @@ String getMapMarkerUrl({
       return Utils.buildUrl(
         url: Platform.isIOS ? 'comgooglemaps://' : 'geo:${coords.latitude},${coords.longitude}',
         queryParams: {
-          'q': '$title',
+          'q': title != null && title != '' ? '$title' : '${coords.latitude},${coords.longitude}',
           'zoom': '$zoomLevel',
           'center': Platform.isIOS ? '${coords.latitude},${coords.longitude}' : ''
         },


### PR DESCRIPTION
This is to 'bypass' the [known issue](https://pub.dev/packages/map_launcher#known-issues) with android google maps. [(google issue tracker)](https://issuetracker.google.com/issues/129726279).

As long as the title passed is correct enough for Google maps to find the right place near the given coordinates, the correct place will be found, see this section of the [Google Maps documentation](https://developers.google.com/maps/documentation/urls/android-intents#search_for_a_location). If no title is given, then obviously no label will be shown. 

I also changed the url for iOS to use the 'center' query parameter as described [here](https://developers.google.com/maps/documentation/urls/ios-urlscheme#display_a_map).

I hope you'll find it interesting. The ideal solution would obviously be that google fix their own issue ;)
