### PR TITLE
fix null origin

### DIFF
--- a/lib/src/map_launcher.dart
+++ b/lib/src/map_launcher.dart
@@ -84,7 +84,7 @@ class MapLauncher {
 
     Map<String, String> args = {
       'mapType': Utils.enumToString(mapType),
-      'url': Uri.encodeFull(url),
+      'url': Uri.encodeFull(url.replaceAll('&origin=null,null', '')),
       'destinationTitle': destinationTitle,
       'destinationLatitude': destination.latitude.toString(),
       'destinationLongitude': destination.longitude.toString(),

--- a/lib/src/map_launcher.dart
+++ b/lib/src/map_launcher.dart
@@ -82,18 +82,22 @@ class MapLauncher {
       extraParams: extraParams,
     );
 
-    final Map<String, String> args = {
+    Map<String, String> args = {
       'mapType': Utils.enumToString(mapType),
       'url': Uri.encodeFull(url),
       'destinationTitle': destinationTitle,
       'destinationLatitude': destination.latitude.toString(),
       'destinationLongitude': destination.longitude.toString(),
       'destinationtitle': destinationTitle,
-      'originLatitude': origin?.latitude?.toString(),
-      'originLongitude': origin?.longitude?.toString(),
       'origintitle': originTitle,
       'directionsMode': Utils.enumToString(directionsMode),
     };
+
+    if (origin?.latitude != null && origin?.longitude != null) {
+      args['originLatitude'] = origin?.latitude?.toString();
+      args['originLongitude'] = origin?.longitude?.toString();
+    }
+
     return _channel.invokeMethod('showDirections', args);
   }
 


### PR DESCRIPTION
if origin is NULL (for example disabled geolocation on device) google maps will find some object on map with name which contains NULL in title and think that this is an origin