### PR TITLE
Add optional waypoint titles for Apple Maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0
+- BREAKING: waypoints parameter now uses `List<Waypoint>` instead of `List<Coord>``
+- Added support for waypoint labels for Apple Maps 
+
 ## 2.5.0+1
 - Update screenshots
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Currently supported maps:
 
 ```yaml
 dependencies:
-  map_launcher: ^2.5.0
+  map_launcher: ^3.0.0
   flutter_svg: # only if you want to use icons as they are svgs
 ```
 
@@ -114,7 +114,7 @@ if (await MapLauncher.isMapAvailable(MapType.google)) {
 ##### Maps
 
 | `mapType`     | `coords`                                                                 | `title`                                        | `description` | `zoom`       | `extraParams` |
-|---------------|--------------------------------------------------------------------------|------------------------------------------------|---------------|--------------|---------------|
+| ------------- | ------------------------------------------------------------------------ | ---------------------------------------------- | ------------- | ------------ | ------------- |
 | `.google`     | ✓                                                                        | iOS only <br /> see Known Issues section below | ✗             | ✓            | ✓             |
 | `.apple`      | ✓                                                                        | ✓                                              | ✗             | ✗            | ✓             |
 | `.googleGo`   | ✓                                                                        | ✗                                              | ✗             | ✓            | ✓             |
@@ -136,23 +136,23 @@ if (await MapLauncher.isMapAvailable(MapType.google)) {
 
 ### Show Directions
 
-| option             | type                      | required | default          |
-| ------------------ | ------------------------- | -------- | ---------------- |
-| `mapType`          | `MapType`                 | yes      | -                |
-| `destination`      | `Coords(lat, long)`       | yes      | -                |
-| `destinationTitle` | `String`                  | no       | `'Destination'`  |
-| `origin`           | `Coords(lat, long)`       | no       | Current Location |
-| `originTitle`      | `String`                  | no       | `'Origin'`       |
-| `directionsMode`   | `DirectionsMode`          | no       | `.driving`       |
-| `waypoints`        | `List<Coords(lat, long)>` | no       | `null`           |
-| `extraParams`      | `Map<String, String>`     | no       | `{}`             |
+| option             | type                                 | required | default          |
+| ------------------ | ------------------------------------ | -------- | ---------------- |
+| `mapType`          | `MapType`                            | yes      | -                |
+| `destination`      | `Coords(lat, long)`                  | yes      | -                |
+| `destinationTitle` | `String`                             | no       | `'Destination'`  |
+| `origin`           | `Coords(lat, long)`                  | no       | Current Location |
+| `originTitle`      | `String`                             | no       | `'Origin'`       |
+| `directionsMode`   | `DirectionsMode`                     | no       | `.driving`       |
+| `waypoints`        | `List<Waypoint(lat, long, String?)>` | no       | `null`           |
+| `extraParams`      | `Map<String, String>`                | no       | `{}`             |
 
 ##### Maps
 
 | `mapType`     | `destination` | `destinationTitle` | `origin`                     | `originTitle` | `directionsMode` | `waypoints`                                  | `extraParams` |
-|---------------|---------------|--------------------|------------------------------|---------------|------------------|----------------------------------------------|---------------|
+| ------------- | ------------- | ------------------ | ---------------------------- | ------------- | ---------------- | -------------------------------------------- | ------------- |
 | `.google`     | ✓             | ✗                  | ✓                            | ✗             | ✓                | ✓ (up to 8 on iOS and unlimited? on android) | ✓             |
-| `.apple`      | ✓             | ✓                  | ✓                            | ✓             | ✓                | ✗                                            | ✓             |
+| `.apple`      | ✓             | ✓                  | ✓                            | ✓             | ✓                | ✓                                            | ✓             |
 | `.googleGo`   | ✓             | ✗                  | ✓                            | ✗             | ✓                | ✓                                            | ✓             |
 | `.amap`       | ✓             | ✓                  | ✓                            | ✓             | ✓                | ✗                                            | ✓             |
 | `.baidu`      | ✓             | ✓                  | ✓                            | ✓             | ✓                | ✗                                            | ✓             |

--- a/example/lib/show_directions.dart
+++ b/example/lib/show_directions.dart
@@ -19,8 +19,8 @@ class _ShowDirectionsState extends State<ShowDirections> {
   String originTitle = 'Pier 33';
 
   // List<Coords> waypoints = [];
-  List<Coords> waypoints = [
-    Coords(37.7705112, -122.4108267),
+  List<Waypoint> waypoints = [
+    Waypoint(Coords(37.7705112, -122.4108267)),
     // Coords(37.6988984, -122.4830961),
     // Coords(37.7935754, -122.483654),
   ];
@@ -193,12 +193,12 @@ class FormTitle extends StatelessWidget {
 }
 
 class WaypointsForm extends StatelessWidget {
-  final List<Coords> waypoints;
-  final void Function(List<Coords> waypoints) onWaypointsUpdated;
+  final List<Waypoint> waypoints;
+  final void Function(List<Waypoint> waypoints) onWaypointsUpdated;
 
   WaypointsForm({required this.waypoints, required this.onWaypointsUpdated});
 
-  void updateWaypoint(Coords waypoint, int index) {
+  void updateWaypoint(Waypoint waypoint, int index) {
     final tempWaypoints = [...waypoints];
     tempWaypoints[index] = waypoint;
     onWaypointsUpdated(tempWaypoints);
@@ -229,7 +229,10 @@ class WaypointsForm extends StatelessWidget {
               initialValue: waypoint.latitude.toString(),
               onChanged: (newValue) {
                 updateWaypoint(
-                  Coords(double.tryParse(newValue) ?? 0, waypoint.longitude),
+                  Waypoint(
+                    Coords(double.tryParse(newValue) ?? 0, waypoint.longitude),
+                    waypoint.title,
+                  ),
                   waypointIndex,
                 );
               },
@@ -238,12 +241,29 @@ class WaypointsForm extends StatelessWidget {
               autocorrect: false,
               autovalidateMode: AutovalidateMode.disabled,
               decoration: InputDecoration(
-                labelText: 'Waypoint #$waypointIndex longitude',
+                labelText: 'Waypoint #${waypointIndex + 1} longitude',
               ),
               initialValue: waypoint.longitude.toString(),
               onChanged: (newValue) {
                 updateWaypoint(
-                  Coords(waypoint.latitude, double.tryParse(newValue) ?? 0),
+                  Waypoint(
+                    Coords(waypoint.latitude, double.tryParse(newValue) ?? 0),
+                    waypoint.title,
+                  ),
+                  waypointIndex,
+                );
+              },
+            ),
+            TextFormField(
+              autocorrect: false,
+              autovalidateMode: AutovalidateMode.disabled,
+              decoration: InputDecoration(
+                labelText: 'Waypoint #${waypointIndex + 1} title',
+              ),
+              initialValue: waypoint.title,
+              onChanged: (newValue) {
+                updateWaypoint(
+                  Waypoint(Coords(waypoint.latitude, waypoint.longitude), newValue),
                   waypointIndex,
                 );
               },
@@ -261,7 +281,7 @@ class WaypointsForm extends StatelessWidget {
               ),
             ),
             onPressed: () {
-              onWaypointsUpdated([...waypoints]..add(Coords(0, 0)));
+              onWaypointsUpdated([...waypoints]..add(Waypoint(Coords(0, 0))));
             },
           ),
         ]),

--- a/example/lib/show_directions.dart
+++ b/example/lib/show_directions.dart
@@ -20,7 +20,7 @@ class _ShowDirectionsState extends State<ShowDirections> {
 
   // List<Coords> waypoints = [];
   List<Waypoint> waypoints = [
-    Waypoint(Coords(37.7705112, -122.4108267)),
+    Waypoint(37.7705112, -122.4108267),
     // Coords(37.6988984, -122.4830961),
     // Coords(37.7935754, -122.483654),
   ];
@@ -230,7 +230,8 @@ class WaypointsForm extends StatelessWidget {
               onChanged: (newValue) {
                 updateWaypoint(
                   Waypoint(
-                    Coords(double.tryParse(newValue) ?? 0, waypoint.longitude),
+                    double.tryParse(newValue) ?? 0,
+                    waypoint.longitude,
                     waypoint.title,
                   ),
                   waypointIndex,
@@ -247,7 +248,8 @@ class WaypointsForm extends StatelessWidget {
               onChanged: (newValue) {
                 updateWaypoint(
                   Waypoint(
-                    Coords(waypoint.latitude, double.tryParse(newValue) ?? 0),
+                    waypoint.latitude,
+                    double.tryParse(newValue) ?? 0,
                     waypoint.title,
                   ),
                   waypointIndex,
@@ -263,7 +265,7 @@ class WaypointsForm extends StatelessWidget {
               initialValue: waypoint.title,
               onChanged: (newValue) {
                 updateWaypoint(
-                  Waypoint(Coords(waypoint.latitude, waypoint.longitude), newValue),
+                  Waypoint(waypoint.latitude, waypoint.longitude, newValue),
                   waypointIndex,
                 );
               },
@@ -281,7 +283,7 @@ class WaypointsForm extends StatelessWidget {
               ),
             ),
             onPressed: () {
-              onWaypointsUpdated([...waypoints]..add(Waypoint(Coords(0, 0))));
+              onWaypointsUpdated([...waypoints]..add(Waypoint(0, 0)));
             },
           ),
         ]),

--- a/ios/Classes/SwiftMapLauncherPlugin.swift
+++ b/ios/Classes/SwiftMapLauncherPlugin.swift
@@ -67,11 +67,13 @@ private func getMapByRawMapType(type: String) -> Map? {
     return maps.first(where: { $0.mapType.type() == type })
 }
 
-private func getMapItem(latitude: String, longitude: String) -> MKMapItem {
+private func getMapItem(latitude: String, longitude: String, name: String?) -> MKMapItem {
     let coordinate = CLLocationCoordinate2DMake(Double(latitude)!, Double(longitude)!)
     let destinationPlacemark = MKPlacemark(coordinate: coordinate, addressDictionary: nil)
 
-    return MKMapItem(placemark: destinationPlacemark);
+    let mapItem = MKMapItem(placemark: destinationPlacemark)
+    mapItem.name = name
+    return mapItem
 }
 
 private func getDirectionsMode(directionsMode: String?) -> String {
@@ -113,25 +115,22 @@ private func showMarker(mapType: MapType, url: String, title: String, latitude: 
     }
 }
 
-private func showDirections(mapType: MapType, url: String, destinationTitle: String?, destinationLatitude: String, destinationLongitude: String, originTitle: String?, originLatitude: String?, originLongitude: String?, directionsMode: String?, waypoints: [[String: String]]?) {
+private func showDirections(mapType: MapType, url: String, destinationTitle: String?, destinationLatitude: String, destinationLongitude: String, originTitle: String?, originLatitude: String?, originLongitude: String?, directionsMode: String?, waypoints: [[String: String?]]?) {
     switch mapType {
     case MapType.apple:
 
-        let destinationMapItem = getMapItem(latitude: destinationLatitude, longitude: destinationLongitude);
-        destinationMapItem.name = destinationTitle ?? "Destination"
+        let destinationMapItem = getMapItem(latitude: destinationLatitude, longitude: destinationLongitude, name: destinationTitle ?? "Destination");
 
         let hasOrigin = originLatitude != nil && originLatitude != nil
         var originMapItem: MKMapItem {
             if !hasOrigin {
                 return MKMapItem.forCurrentLocation()
             }
-            let origin = getMapItem(latitude: originLatitude!, longitude: originLongitude!)
-            origin.name = originTitle ?? "Origin"
+            let origin = getMapItem(latitude: originLatitude!, longitude: originLongitude!, name: originTitle ?? "Origin")
             return origin
         }
         
-        let waypointMapItems = waypoints == nil ? [MKMapItem]() : waypoints!.map { getMapItem(latitude: $0["latitude"]!, longitude: $0["longitude"]!) }
-
+        let waypointMapItems = waypoints == nil ? [MKMapItem]() : waypoints!.map { getMapItem(latitude: $0["latitude"]!!, longitude: $0["longitude"]!!, name: $0["title"] as? String) }
 
         MKMapItem.openMaps(
             with: [originMapItem] + waypointMapItems + [destinationMapItem],
@@ -199,7 +198,7 @@ public class SwiftMapLauncherPlugin: NSObject, FlutterPlugin {
 
       let directionsMode = args["directionsMode"] as? String
 
-      let waypoints = args["waypoints"] as? [[String: String]]
+      let waypoints = args["waypoints"] as? [[String: String?]]
 
       let map = getMapByRawMapType(type: mapType)
       if (!isMapAvailable(map: map)) {

--- a/lib/src/directions_url.dart
+++ b/lib/src/directions_url.dart
@@ -10,7 +10,7 @@ String getMapDirectionsUrl({
   Coords? origin,
   String? originTitle,
   DirectionsMode? directionsMode,
-  List<Coords>? waypoints,
+  List<Waypoint>? waypoints,
   Map<String, String>? extraParams,
 }) {
   switch (mapType) {
@@ -25,7 +25,7 @@ String getMapDirectionsUrl({
             '${origin?.latitude},${origin?.longitude}',
           ),
           'waypoints': waypoints
-              ?.map((coords) => '${coords.latitude},${coords.longitude}')
+              ?.map((waypoint) => '${waypoint.latitude},${waypoint.longitude}')
               .join('|'),
           'travelmode': Utils.enumToString(directionsMode),
           ...(extraParams ?? {}),
@@ -43,7 +43,7 @@ String getMapDirectionsUrl({
             '${origin?.latitude},${origin?.longitude}',
           ),
           'waypoints': waypoints
-              ?.map((coords) => '${coords.latitude},${coords.longitude}')
+              ?.map((waypoint) => '${waypoint.latitude},${waypoint.longitude}')
               .join('|'),
           'travelmode': Utils.enumToString(directionsMode),
           ...(extraParams ?? {}),

--- a/lib/src/map_launcher.dart
+++ b/lib/src/map_launcher.dart
@@ -70,7 +70,7 @@ class MapLauncher {
     String? destinationTitle,
     Coords? origin,
     String? originTitle,
-    List<Coords>? waypoints,
+    List<Waypoint>? waypoints,
     DirectionsMode? directionsMode = DirectionsMode.driving,
     Map<String, String>? extraParams,
   }) async {
@@ -100,6 +100,7 @@ class MapLauncher {
           .map((waypoint) => {
                 'latitude': waypoint.latitude.toString(),
                 'longitude': waypoint.longitude.toString(),
+                'title': waypoint.title,
               })
           .toList(),
     };

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -44,7 +44,7 @@ class Waypoint {
   final Coords coords;
   final String? title;
 
-  Waypoint(this.coords, [this.title]);
+  Waypoint(double latitude, double longitude, [this.title]) : coords = Coords(latitude, longitude);
 
   double get latitude => coords.latitude;
   double get longitude => coords.longitude;

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -39,6 +39,17 @@ class Coords {
   Coords(this.latitude, this.longitude);
 }
 
+/// Class that holds lat/lng coordinates and optional title
+class Waypoint {
+  final Coords coords;
+  final String? title;
+
+  Waypoint(this.coords, [this.title]);
+
+  double get latitude => coords.latitude;
+  double get longitude => coords.longitude;
+}
+
 /// Class that holds all the information needed to launch a map
 class AvailableMap {
   String mapName;
@@ -53,8 +64,7 @@ class AvailableMap {
 
   /// Parses json object to [AvailableMap]
   static AvailableMap? fromJson(json) {
-    final MapType? mapType =
-        Utils.enumFromString(MapType.values, json['mapType']);
+    final MapType? mapType = Utils.enumFromString(MapType.values, json['mapType']);
     if (mapType != null) {
       return AvailableMap(
         mapName: json['mapName'],
@@ -90,7 +100,7 @@ class AvailableMap {
     String? destinationTitle,
     Coords? origin,
     String? originTitle,
-    List<Coords>? waypoints,
+    List<Waypoint>? waypoints,
     DirectionsMode directionsMode = DirectionsMode.driving,
     Map<String, String>? extraParams,
   }) {


### PR DESCRIPTION
See #113.

Creates a new Waypoint class that wraps Coords and accepts an optional title. Because the refactor changes `waypoints` from `List<Coord>` into `List<Waypoint>`, this would be a **breaking change** with how `showDirections` is called.  

Because the Android implementation appears to solely rely on URL construction (via `getMapDirectionsUrl`), I didn't have to adjust anything there - just the iOS implementation and common dart code. 

This will only work for Apple Maps, as Google doesn't support waypoint labels :/

I've never worked with platform-specific plugin code and had to learn Swift (🤯) to figure this out, so please take a look!

I've tested the iOS example as well as the package in my own project for both Apple Maps iOS and Google Maps on Android.   