### PR TITLE
feat: make the destination parameter of showDirections() be nullable. (NEW)

### DIFF
--- a/ios/Classes/SwiftMapLauncherPlugin.swift
+++ b/ios/Classes/SwiftMapLauncherPlugin.swift
@@ -111,9 +111,8 @@ private func getDirectionsMode(directionsMode: String?) -> String {
     }
 }
 
-private func showMarker(mapType: MapType, url: String, title: String, latitude: String, longitude: String) {
-    switch mapType {
-    case MapType.apple:
+private func showMarker(mapType: MapType, url: String, title: String, latitude: String, longitude: String, perfectUseMapKit: Bool) {
+    if (mapType == MapType.apple && perfectUseMapKit) {
         let coordinate = CLLocationCoordinate2DMake(Double(latitude)!, Double(longitude)!)
         let region = MKCoordinateRegion(center: coordinate, span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.02))
         let placemark = MKPlacemark(coordinate: coordinate, addressDictionary: nil)
@@ -123,15 +122,13 @@ private func showMarker(mapType: MapType, url: String, title: String, latitude: 
             MKLaunchOptionsMapSpanKey: NSValue(mkCoordinateSpan: region.span)]
         mapItem.name = title
         mapItem.openInMaps(launchOptions: options)
-    default:
+    } else {
         UIApplication.shared.open(URL(string:url)!, options: [:], completionHandler: nil)
-
     }
 }
 
-private func showDirections(mapType: MapType, url: String, destinationTitle: String?, destinationLatitude: String, destinationLongitude: String, originTitle: String?, originLatitude: String?, originLongitude: String?, directionsMode: String?, waypoints: [[String: String?]]?) {
-    switch mapType {
-    case MapType.apple:
+private func showDirections(mapType: MapType, url: String, destinationTitle: String?, destinationLatitude: String, destinationLongitude: String, originTitle: String?, originLatitude: String?, originLongitude: String?, directionsMode: String?, waypoints: [[String: String?]]?, perfectUseMapKit: Bool) {
+    if (mapType == MapType.apple && perfectUseMapKit) {
 
         let destinationMapItem = getMapItem(latitude: destinationLatitude, longitude: destinationLongitude, name: destinationTitle ?? "Destination");
 
@@ -150,9 +147,8 @@ private func showDirections(mapType: MapType, url: String, destinationTitle: Str
             with: [originMapItem] + waypointMapItems + [destinationMapItem],
             launchOptions: [MKLaunchOptionsDirectionsModeKey: getDirectionsMode(directionsMode: directionsMode)]
         )
-    default:
+    } else {
         UIApplication.shared.open(URL(string:url)!, options: [:], completionHandler: nil)
-
     }
 }
 
@@ -188,6 +184,7 @@ public class SwiftMapLauncherPlugin: NSObject, FlutterPlugin {
             let title = args["title"] as! String
             let latitude = args["latitude"] as! String
             let longitude = args["longitude"] as! String
+      let perfectUseMapKit = (args["perfectUseMapKit"] as? NSNumber)?.boolValue ?? true
 
             let map = getMapByRawMapType(type: mapType)
             if (!isMapAvailable(map: map)) {
@@ -195,13 +192,21 @@ public class SwiftMapLauncherPlugin: NSObject, FlutterPlugin {
                 return;
             }
 
-            showMarker(mapType: MapType(rawValue: mapType)!, url: url, title: title, latitude: latitude, longitude: longitude)
+            showMarker(
+        mapType: MapType(rawValue: mapType)!,
+        url: url,
+        title: title,
+        latitude: latitude,
+        longitude: longitude,
+        perfectUseMapKit: perfectUseMapKit
+      )
             result(nil)
 
         case "showDirections":
             let args = call.arguments as! NSDictionary
             let mapType = args["mapType"] as! String
             let url = args["url"] as! String
+      let perfectUseMapKit = (args["perfectUseMapKit"] as? NSNumber)?.boolValue ?? true
 
             let destinationTitle = args["destinationTitle"] as? String
             let destinationLatitude = args["destinationLatitude"] as! String
@@ -231,7 +236,8 @@ public class SwiftMapLauncherPlugin: NSObject, FlutterPlugin {
                 originLatitude: originLatitude,
                 originLongitude: originLongitude,
                 directionsMode: directionsMode,
-                waypoints: waypoints
+                waypoints: waypoints,
+                perfectUseMapKit: perfectUseMapKit
             )
             result(nil)
 

--- a/lib/src/map_launcher.dart
+++ b/lib/src/map_launcher.dart
@@ -49,9 +49,20 @@ class MapLauncher {
 
   /// Opens map app specified in [mapType]
   /// and shows directions to [destination]
+  ///
+  /// [destination], the coordinates of the destination. When it is `null`, use
+  /// [destinationTitle] to search destination, currently only some maps support it.
+  ///
+  /// - [MapType.apple], supported
+  /// - [MapType.google], supported
+  /// - [MapType.googleGo], supported
+  /// - [MapType.amap], supported
+  /// - [MapType.baidu], supported
+  /// - [MapType.tencent], partially supported, you need to manually click the input box to search.
+  /// - others map not tested, fallback to [Coords.zero]
   static Future<dynamic> showDirections({
     required MapType mapType,
-    required Coords destination,
+    required Coords? destination,
     String? destinationTitle,
     Coords? origin,
     String? originTitle,
@@ -73,10 +84,11 @@ class MapLauncher {
     final Map<String, dynamic> args = {
       'mapType': Utils.enumToString(mapType),
       'url': Uri.encodeFull(url),
+      // On iOS, MapKit does not support destination being null, use `UIApplication.shared.open()` instead.
+      'perfectUseMapKit': destination != null,
       'destinationTitle': destinationTitle,
-      'destinationLatitude': destination.latitude.toString(),
-      'destinationLongitude': destination.longitude.toString(),
-      'destinationtitle': destinationTitle,
+      'destinationLatitude': (destination?.latitude ?? 0.0).toString(),
+      'destinationLongitude': (destination?.longitude ?? 0.0).toString(),
       'originLatitude': origin?.latitude.toString(),
       'originLongitude': origin?.longitude.toString(),
       'originTitle': originTitle,

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -101,10 +101,12 @@ enum DirectionsMode {
 
 /// Class that holds latitude and longitude coordinates
 class Coords {
+  static const zero = Coords(0.0, 0.0);
+
   final double latitude;
   final double longitude;
 
-  Coords(this.latitude, this.longitude);
+  const Coords(this.latitude, this.longitude);
 }
 
 /// Class that holds lat/lng coordinates and optional title
@@ -166,7 +168,7 @@ class AvailableMap {
 
   /// Launches current map and shows directions to `destination`
   Future<void> showDirections({
-    required Coords destination,
+    required Coords? destination,
     String? destinationTitle,
     Coords? origin,
     String? originTitle,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -140,4 +140,19 @@ class Utils {
         return 'd';
     }
   }
+
+  /// Returns [DirectionsMode] for [MapType.apple]
+  static String? getAppleDirectionsMode(DirectionsMode? directionsMode) {
+    switch (directionsMode) {
+      case DirectionsMode.driving:
+        return 'd';
+      case DirectionsMode.walking:
+        return 'w';
+      case DirectionsMode.transit:
+        return 'r';
+      case DirectionsMode.bicycling:
+      case null:
+        return null;
+    }
+  }
 }


### PR DESCRIPTION
When it is null, use [destinationTitle] to search destination, currently only some maps support it.

[MapType.apple], supported
[MapType.google], supported
[MapType.googleGo], supported
[MapType.amap], supported
[MapType.baidu], supported
[MapType.tencent], partially supported, you need to manually click the input box to search.
others map not tested, fallback to [Coords.zero]