### PR TITLE
fix: url encoding of query parameters & Amap has been unavailable since version 4.0.1 (url are automatically converted to lowercase)

### DIFF
--- a/lib/src/utils/url_builder.dart
+++ b/lib/src/utils/url_builder.dart
@@ -8,13 +8,11 @@ String buildUrl({
   required String url,
   required Map<String, String> queryParams,
 }) {
-  final base = Uri.parse(url);
-
-  final cleaned = <String, String>{
-    for (final e in queryParams.entries)
-      if (e.value.trim().isNotEmpty) e.key: e.value,
-  };
-
-  final merged = {...base.queryParameters, ...cleaned};
-  return base.replace(queryParameters: merged).toString();
+  return queryParams.entries
+      .fold('$url?', (dynamic previousValue, element) {
+    if (element.value == null || element.value == '') {
+      return previousValue;
+    }
+    return '$previousValue&${Uri.encodeQueryComponent(element.key)}=${Uri.encodeQueryComponent(element.value)}';
+  }).replaceFirst('&', '');
 }


### PR DESCRIPTION
Amap has been unavailable since version 4.0.1：
url are automatically converted to lowercase
String url = 'androidamap://viewMap';
final base = Uri.parse(url);// androidamap://viewmap